### PR TITLE
sanitize episode parsing: remove trailing 0,

### DIFF
--- a/eztv_api.js
+++ b/eztv_api.js
@@ -91,8 +91,8 @@ exports.getAllEpisodes = function(data, cb) {
             var entry = $(this);
             var title = entry.children('td').eq(1).text();
             var magnet = entry.children('td').eq(2).children('a').first().attr('href');
-            var matcher = title.match(/S([0-9]+)E([0-9]+)/);
-            if(!matcher) matcher = title.match(/([0-9]+)x([0-9]+)/);
+            var matcher = title.match(/S0?([0-9]+)E0?([0-9]+)/);
+            if(!matcher) matcher = title.match(/0?([0-9]+)x0?([0-9]+)/);
             if(matcher) {
                 var season = matcher[1];
                 var episode = matcher[2];


### PR DESCRIPTION
before blah-gnu-S01E03 would yield 01, 03, now it gives 1 and 3.
makes things more consistent.

Signed-off-by: Niv Sardi xaiki@evilgiggle.com
